### PR TITLE
Improve speed and correctness of existing in-band mapping tests

### DIFF
--- a/mpegmap/HTMLSourcingInbandTracks-3.1-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.1-1.html
@@ -38,26 +38,23 @@
 
       // In test media file the PMT 'ES apperance order'
       // is the same as the assending order of ES PIDs.
-      var pids = ['1770', '1768', '45'];                // SCTE-35, EISS, EBIF PIDS
+      var pids = ['1770', '1768', '45']; // SCTE-35, EISS, EBIF PIDS
  
       vid.addEventListener("playing", function() {
-        setTimeout(function() {
+        vid.pause();
 
-          vid.pause();
-
-          test.step(function() {
-            // Make sure the three required tracks are in order
-            var next = 0;
-            for (i = 0; i < vid.textTracks.length; i++) {
-              if (pids.indexOf(vid.textTracks[i].id) >= 0) {
-                assert_equals(pids[next], vid.textTracks[i].id, "TextTrackList Order");
-                next++;
-              }
+        test.step(function() {
+          // Make sure the three required tracks are in order
+          var next = 0;
+          for (var i = 0; i < vid.textTracks.length; i++) {
+            if (pids.indexOf(vid.textTracks[i].id) >= 0) {
+              assert_equals(pids[next], vid.textTracks[i].id, "TextTrackList Order");
+              next++;
             }
-          }, "TextTrackListOrder.");
+          }
+        }, "TextTrackListOrder.");
 
-          test.done();
-        }, 15000);
+        test.done();
       }, false);
     </script>
   </body>

--- a/mpegmap/HTMLSourcingInbandTracks-3.1-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.1-1.html
@@ -10,22 +10,19 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The test media is an MPEG-2, Single Program Transport Stream
-           containing two EISS streams, and one program insertion cue stream.
-           In test media file the PMT 'ES apperance order'
-           is the same as the assending order of ES PIDs.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The test media is an MPEG-2, Single Program Transport Stream
+         containing two EISS streams, and one program insertion cue stream.
+         In test media file the PMT 'ES apperance order'
+         is the same as the assending order of ES PIDs.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
@@ -34,8 +31,6 @@
 
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
-
-
     <script>
       var test = async_test("TextTrackList order.");
       var vid = document.getElementById("v");
@@ -51,20 +46,19 @@
           vid.pause();
 
           test.step(function() {
-	    // Make sure the three required tracks are in order
-	    var next = 0;
-	    for (i = 0; i < vid.textTracks.length; i++) {
+            // Make sure the three required tracks are in order
+            var next = 0;
+            for (i = 0; i < vid.textTracks.length; i++) {
               if (pids.indexOf(vid.textTracks[i].id) >= 0) {
-		assert_equals(pids[next], vid.textTracks[i].id, "TextTrackList Order");
-		next++;
-	      }
+                assert_equals(pids[next], vid.textTracks[i].id, "TextTrackList Order");
+                next++;
+              }
             }
           }, "TextTrackListOrder.");
 
           test.done();
         }, 15000);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-1.html
@@ -34,98 +34,85 @@
       var vid = document.getElementById("v");
       vid.src = mediaServerURL() + "UserPrivateStreams.ts";
 
-      var hexEiss = '0xA2';
-      var eissDesc = parseInt(hexEiss, 16);  // EISS Descriptor 0xA2
-      var eissPid = 1768;  // EISS PID
-
-      var hexEbif = '0xA1';
-      var ebifDesc = parseInt(hexEbif, 16);  // EBIF Descriptor 0xA1
-      var ebifPid = 1770;  // EBIF PID
-      var indexEiss = -1;
-      var indexEbif = -1;
+      var eissPid = 1768;
+      var ebifPid = 1770;
+      var eissTrack = null;
+      var ebifTrack = null;
 
       // TextTrack[index].cues is a list.  Each cue in the list will have a unique data attribute value.
       // This script tests that all cues are instanceof ArrayBuffer.
       // This script tests TextTrack[index].cues[0].data only for value.
-      var dataEiss = [224, 0, 114, 0, 0, 0, 3, 0, 0, 8, 0, 255, 255, 255, 0, 1, 0, 224, 94, 1, 1, 0, 0, 0, 0, 0, 0, 0, 100, 16, 82, 0, 80, 108, 105, 100, 58, 47, 47, 105, 98, 46, 116, 118, 119, 111, 114, 107, 115, 46, 99, 111, 109, 47, 67, 97, 98, 108, 101, 108, 97, 98, 115, 95, 78, 97, 116, 105, 111, 110, 97, 108, 95, 101, 116, 118, 95, 115, 116, 114, 101, 97, 109, 95, 99, 111, 110, 102, 105, 103, 47, 109, 97, 105, 110, 97, 112, 112, 47, 49, 46, 48, 47, 109, 97, 105, 110, 95, 112, 114, 46, 112, 114, 90, 3, 153, 38]; 
+      var dataEiss = [224, 0, 114, 0, 0, 0, 3, 0, 0, 8, 0, 255, 255, 255, 0, 1, 0, 224, 94, 1, 1, 0, 0, 0, 0, 0, 0, 0, 100, 16, 82, 0, 80, 108, 105, 100, 58, 47, 47, 105, 98, 46, 116, 118, 119, 111, 114, 107, 115, 46, 99, 111, 109, 47, 67, 97, 98, 108, 101, 108, 97, 98, 115, 95, 78, 97, 116, 105, 111, 110, 97, 108, 95, 101, 116, 118, 95, 115, 116, 114, 101, 97, 109, 95, 99, 111, 110, 102, 105, 103, 47, 109, 97, 105, 110, 97, 112, 112, 47, 49, 46, 48, 47, 109, 97, 105, 110, 95, 112, 114, 46, 112, 114, 90, 3, 153, 38];
 
       var dataEbif = [227 , 64 , 136 , 251 , 251 , 0 , 59 , 176 , 126 , 0 , 1 , 193 , 0 , 0 , 17 , 3 , 16 , 2 , 128 , 0 , 0 , 1 , 255 , 0 , 0 , 105 , 0 , 0 , 0 , 1 , 3 , 216 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 1 , 0 , 1 , 0 , 0 , 2 , 12 , 1 , 60 , 59 , 67 , 97 , 98 , 108 , 101 , 108 , 97 , 98 , 115 , 95 , 78 , 97 , 116 , 105 , 111 , 110 , 97 , 108 , 95 , 101 , 116 , 118 , 95 , 115 , 116 , 114 , 101 , 97 , 109 , 95 , 99 , 111 , 110 , 102 , 105 , 103 , 47 , 109 , 97 , 105 , 110 , 97 , 112 , 112 , 47 , 49 , 46 , 48 , 47 , 109 , 97 , 105 , 110 , 95 , 112 , 114 , 46 , 112 , 114 , 0 , 15 , 14 , 105 , 98 , 46 , 116 , 118 , 119 , 111 , 114 , 107 , 115 , 46 , 99 , 111 , 109 , 225 , 54 , 136 , 221 , 188 , 252 , 142 , 137];
 
-      vid.addEventListener("playing", function() {
-        setTimeout(function() {
-          for (var i = 0; i < vid.textTracks.length; i++) {
-            if (vid.textTracks[i].id == eissPid) {
-              vid.textTracks[i].mode = 'hidden';
-              indexEiss = i;
-            }
-            if (vid.textTracks[i].id == ebifPid) {
-              vid.textTracks[i].mode = 'hidden';
-              indexEbif = i;
-            }
-          }
-        }, 6000);
+      vid.textTracks.addEventListener("addtrack", function(event) {
+        if (event.track.id == eissPid) {
+          eissTrack = event.track;
+        } else if (event.track.id == ebifPid) {
+          ebifTrack = event.track;
+        }
+        event.track.mode = "hidden";
+      });
 
+      vid.addEventListener("playing", function() {
         setTimeout(function() {
           vid.pause();
 
-          if (indexEiss == -1) {
+          if (!eissTrack) {
             test.step(function() {
               assert_unreached("Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
             }, "Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
             test.done();
-          }
-          else if (indexEbif == -1) {
+          } else if (!ebifTrack) {
             test.step(function() {
               assert_unreached("Did not find EISS TextTrack.id (" + ebifPid + ") in DOM.");
             }, "Did not find EISS TextTrack.id (" + ebifPid + ") in DOM.");
             test.done();
-
           } else {
             test.step(function() {
               // EISS
-              for (var i = 0; i < vid.textTracks[indexEiss].cues.length; i++) {
-                var startTime = vid.textTracks[indexEiss].cues[i].startTime;
-                var endTime = vid.textTracks[indexEiss].cues[i].endTime;
-                var id = vid.textTracks[indexEiss].cues[i].id;
+              for (var i = 0; i < eissTrack.cues.length; i++) {
+                var cue = eissTrack.cues[i];
+                var startTime = cue.startTime;
+                var endTime = cue.endTime;
 
-                assert_equals(id, eissDesc, "DataCue.id");
+                assert_equals(cue.id, "", "DataCue.id");
 
                 if (i <= 13) {
-                  assert_equals(startTime, 0, "DataCue.startTime");
+                  assert_approx_equals(startTime, 0, 0.1, "DataCue.startTime");
                 } else if (i <= 14) {
-                   assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime");
+                  assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime");
                 } else if (i <= 15) {
-                   assert_approx_equals(startTime, 3.52, 0.1, "DataCue.startTime");
+                  assert_approx_equals(startTime, 3.52, 0.1, "DataCue.startTime");
                 } else if (i <= 16) {
-                   assert_approx_equals(startTime, 4.79, 0.1, "DataCue.startTime");
+                  assert_approx_equals(startTime, 4.79, 0.1, "DataCue.startTime");
                 } else if (i <= 17) {
-                   assert_approx_equals(startTime, 5.59, 0.1, "DataCue.startTime");
+                  assert_approx_equals(startTime, 5.59, 0.1, "DataCue.startTime");
                 } else if (i <= 18) {
-                   assert_approx_equals(startTime, 8.09, 0.1, "DataCue.startTime");
+                  assert_approx_equals(startTime, 8.09, 0.1, "DataCue.startTime");
                 } else if (i <= 19) {
-                   assert_approx_equals(startTime, 10.46, 0.1, "DataCue.startTime");
+                  assert_approx_equals(startTime, 10.46, 0.1, "DataCue.startTime");
                 }
 
                 assert_greater_than_equal(endTime + 0.01, startTime, "DataCue.endTime");
-                assert_true(vid.textTracks[indexEiss].cues[i].data instanceof ArrayBuffer,
-                            "DataCues[i] is ArrayBuffer");
+                assert_true(cue.data instanceof ArrayBuffer, "DataCue.data is ArrayBuffer");
 
                 if (i === 0) {
-                  var cueData = new Uint8Array(vid.textTracks[indexEiss].cues[0].data);
-                  assert_array_equals(dataEiss, cueData, "DataCues[first] data");
+                  var cueData = new Uint8Array(cue.data);
+                  assert_array_equals(dataEiss, cueData, "EISS DataCue.data");
                 }
 
-                assert_equals(vid.textTracks[indexEiss].cues[i].pauseOnExit, false, "DataCue.pauseOnExit");
-                assert_equals(vid.textTracks[indexEiss].cues[i].text, null, "DataCue.text");
+                assert_equals(cue.pauseOnExit, false, "DataCue.pauseOnExit");
               }
 
               // EBIF
-              for (var i = 0; i < vid.textTracks[indexEbif].cues.length; i++) {
-                var startTime = vid.textTracks[indexEbif].cues[i].startTime;
-                var endTime = vid.textTracks[indexEbif].cues[i].endTime;
-                var id = vid.textTracks[indexEbif].cues[i].id;
+              for (var i = 0; i < ebifTrack.cues.length; i++) {
+                var cue = ebifTrack.cues[i];
+                var startTime = cue.startTime;
+                var endTime = cue.endTime;
 
-                assert_equals(id, ebifDesc, "DataCue.id");
+                assert_equals(cue.id, "", "DataCue.id");
 
                 if (i <= 14) {
                   assert_equals(startTime, 0, "DataCue.startTime");
@@ -144,16 +131,15 @@
                 }
 
                 assert_greater_than_equal(endTime + 0.01, startTime, "DataCue.endTime");
-                assert_true(vid.textTracks[indexEbif].cues[i].data instanceof ArrayBuffer,
-                            "DataCues[i] is ArrayBuffer");
+                assert_true(cue.data instanceof ArrayBuffer,
+                            "DataCue.data is ArrayBuffer");
 
                 if (i === 0) {
-                  var cueData = new Uint8Array(vid.textTracks[indexEbif].cues[0].data);
-                  assert_array_equals(dataEbif, cueData, "DataCues[second] data");
+                  var cueData = new Uint8Array(cue.data);
+                  assert_array_equals(dataEbif, cueData, "EBIF DataCue.data");
                 }
 
-                assert_equals(vid.textTracks[indexEbif].cues[i].pauseOnExit, false, "DataCue.pauseOnExit");
-                assert_equals(vid.textTracks[indexEbif].cues[i].text, null, "DataCue.text");
+                assert_equals(cue.pauseOnExit, false, "DataCue.pauseOnExit");
               }
             }, "EBIF/EISS DataCues attributes.");
             test.done();

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-1.html
@@ -10,20 +10,17 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing two EISS streams, one program insertion cue stream.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing two EISS streams, one program insertion cue stream.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
@@ -32,8 +29,6 @@
 
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
-
-
     <script>
       var test = async_test("EISS DataCues attributes.");
       var vid = document.getElementById("v");
@@ -56,11 +51,9 @@
 
       var dataEbif = [227 , 64 , 136 , 251 , 251 , 0 , 59 , 176 , 126 , 0 , 1 , 193 , 0 , 0 , 17 , 3 , 16 , 2 , 128 , 0 , 0 , 1 , 255 , 0 , 0 , 105 , 0 , 0 , 0 , 1 , 3 , 216 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 1 , 0 , 1 , 0 , 0 , 2 , 12 , 1 , 60 , 59 , 67 , 97 , 98 , 108 , 101 , 108 , 97 , 98 , 115 , 95 , 78 , 97 , 116 , 105 , 111 , 110 , 97 , 108 , 95 , 101 , 116 , 118 , 95 , 115 , 116 , 114 , 101 , 97 , 109 , 95 , 99 , 111 , 110 , 102 , 105 , 103 , 47 , 109 , 97 , 105 , 110 , 97 , 112 , 112 , 47 , 49 , 46 , 48 , 47 , 109 , 97 , 105 , 110 , 95 , 112 , 114 , 46 , 112 , 114 , 0 , 15 , 14 , 105 , 98 , 46 , 116 , 118 , 119 , 111 , 114 , 107 , 115 , 46 , 99 , 111 , 109 , 225 , 54 , 136 , 221 , 188 , 252 , 142 , 137];
 
-
       vid.addEventListener("playing", function() {
-
         setTimeout(function() {
-          for (i=0; i< vid.textTracks.length; i++) {
+          for (var i = 0; i < vid.textTracks.length; i++) {
             if (vid.textTracks[i].id == eissPid) {
               vid.textTracks[i].mode = 'hidden';
               indexEiss = i;
@@ -72,11 +65,10 @@
           }
         }, 6000);
 
-
         setTimeout(function() {
           vid.pause();
 
-          if (indexEiss ==  -1) {
+          if (indexEiss == -1) {
             test.step(function() {
               assert_unreached("Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
             }, "Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
@@ -91,35 +83,34 @@
           } else {
             test.step(function() {
               // EISS
-              for (i=0; i< vid.textTracks[indexEiss].cues.length; i++) {
-
+              for (var i = 0; i < vid.textTracks[indexEiss].cues.length; i++) {
                 var startTime = vid.textTracks[indexEiss].cues[i].startTime;
                 var endTime = vid.textTracks[indexEiss].cues[i].endTime;
                 var id = vid.textTracks[indexEiss].cues[i].id;
 
                 assert_equals(id, eissDesc, "DataCue.id");
 
-		if (i <= 13) {
-		  assert_equals(startTime, 0, "DataCue.startTime");
-		} else if (i <= 14) {
-		   assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime")
-		} else if (i <= 15) {
-		   assert_approx_equals(startTime, 3.52, 0.1, "DataCue.startTime")
-		} else if (i <= 16) {
-		   assert_approx_equals(startTime, 4.79, 0.1, "DataCue.startTime")
-		} else if (i <= 17) {
-		   assert_approx_equals(startTime, 5.59, 0.1, "DataCue.startTime")
-		} else if (i <= 18) {
-		   assert_approx_equals(startTime, 8.09, 0.1, "DataCue.startTime")
-		} else if (i <= 19) {
-		   assert_approx_equals(startTime, 10.46, 0.1, "DataCue.startTime")
-		}
+                if (i <= 13) {
+                  assert_equals(startTime, 0, "DataCue.startTime");
+                } else if (i <= 14) {
+                   assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime");
+                } else if (i <= 15) {
+                   assert_approx_equals(startTime, 3.52, 0.1, "DataCue.startTime");
+                } else if (i <= 16) {
+                   assert_approx_equals(startTime, 4.79, 0.1, "DataCue.startTime");
+                } else if (i <= 17) {
+                   assert_approx_equals(startTime, 5.59, 0.1, "DataCue.startTime");
+                } else if (i <= 18) {
+                   assert_approx_equals(startTime, 8.09, 0.1, "DataCue.startTime");
+                } else if (i <= 19) {
+                   assert_approx_equals(startTime, 10.46, 0.1, "DataCue.startTime");
+                }
 
                 assert_greater_than_equal(endTime + 0.01, startTime, "DataCue.endTime");
                 assert_true(vid.textTracks[indexEiss].cues[i].data instanceof ArrayBuffer,
-			    "DataCues[i] is ArrayBuffer");
+                            "DataCues[i] is ArrayBuffer");
 
-                if (i==0) {
+                if (i === 0) {
                   var cueData = new Uint8Array(vid.textTracks[indexEiss].cues[0].data);
                   assert_array_equals(dataEiss, cueData, "DataCues[first] data");
                 }
@@ -129,34 +120,34 @@
               }
 
               // EBIF
-              for (i=0; i< vid.textTracks[indexEbif].cues.length; i++) {
+              for (var i = 0; i < vid.textTracks[indexEbif].cues.length; i++) {
                 var startTime = vid.textTracks[indexEbif].cues[i].startTime;
                 var endTime = vid.textTracks[indexEbif].cues[i].endTime;
-		var id = vid.textTracks[indexEbif].cues[i].id;
+                var id = vid.textTracks[indexEbif].cues[i].id;
 
                 assert_equals(id, ebifDesc, "DataCue.id");
 
-		if (i <= 14) {
-		  assert_equals(startTime, 0, "DataCue.startTime");
-		} else if (i <= 15) {
-		   assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime")
-		} else if (i <= 16) {
-		   assert_approx_equals(startTime, 3.15, 0.1, "DataCue.startTime")
-		} else if (i <= 17) {
-		   assert_approx_equals(startTime, 4.62, 0.1, "DataCue.startTime")
-		} else if (i <= 18) {
-		   assert_approx_equals(startTime, 5.52, 0.1, "DataCue.startTime")
-		} else if (i <= 19) {
-		   assert_approx_equals(startTime, 8.03, 0.1, "DataCue.startTime")
-		} else if (i <= 20) {
-		   assert_approx_equals(startTime, 10.06, 0.1, "DataCue.startTime")
-		}
+                if (i <= 14) {
+                  assert_equals(startTime, 0, "DataCue.startTime");
+                } else if (i <= 15) {
+                   assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime");
+                } else if (i <= 16) {
+                   assert_approx_equals(startTime, 3.15, 0.1, "DataCue.startTime");
+                } else if (i <= 17) {
+                   assert_approx_equals(startTime, 4.62, 0.1, "DataCue.startTime");
+                } else if (i <= 18) {
+                   assert_approx_equals(startTime, 5.52, 0.1, "DataCue.startTime");
+                } else if (i <= 19) {
+                   assert_approx_equals(startTime, 8.03, 0.1, "DataCue.startTime");
+                } else if (i <= 20) {
+                   assert_approx_equals(startTime, 10.06, 0.1, "DataCue.startTime");
+                }
 
                 assert_greater_than_equal(endTime + 0.01, startTime, "DataCue.endTime");
                 assert_true(vid.textTracks[indexEbif].cues[i].data instanceof ArrayBuffer,
-			    "DataCues[i] is ArrayBuffer");
+                            "DataCues[i] is ArrayBuffer");
 
-                if (i==0) {
+                if (i === 0) {
                   var cueData = new Uint8Array(vid.textTracks[indexEbif].cues[0].data);
                   assert_array_equals(dataEbif, cueData, "DataCues[second] data");
                 }
@@ -169,7 +160,6 @@
           }
         }, 12000);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-1.html
@@ -36,8 +36,15 @@
 
       var eissPid = 1768;
       var ebifPid = 1770;
-      var eissTrack = null;
-      var ebifTrack = null;
+
+      var doneCount = 0;
+      function done() {
+        vid.pause();
+        ++doneCount;
+        if (doneCount >= 2) {
+          test.done();
+        }
+      }
 
       // TextTrack[index].cues is a list.  Each cue in the list will have a unique data attribute value.
       // This script tests that all cues are instanceof ArrayBuffer.
@@ -47,104 +54,52 @@
       var dataEbif = [227 , 64 , 136 , 251 , 251 , 0 , 59 , 176 , 126 , 0 , 1 , 193 , 0 , 0 , 17 , 3 , 16 , 2 , 128 , 0 , 0 , 1 , 255 , 0 , 0 , 105 , 0 , 0 , 0 , 1 , 3 , 216 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 1 , 0 , 1 , 0 , 0 , 2 , 12 , 1 , 60 , 59 , 67 , 97 , 98 , 108 , 101 , 108 , 97 , 98 , 115 , 95 , 78 , 97 , 116 , 105 , 111 , 110 , 97 , 108 , 95 , 101 , 116 , 118 , 95 , 115 , 116 , 114 , 101 , 97 , 109 , 95 , 99 , 111 , 110 , 102 , 105 , 103 , 47 , 109 , 97 , 105 , 110 , 97 , 112 , 112 , 47 , 49 , 46 , 48 , 47 , 109 , 97 , 105 , 110 , 95 , 112 , 114 , 46 , 112 , 114 , 0 , 15 , 14 , 105 , 98 , 46 , 116 , 118 , 119 , 111 , 114 , 107 , 115 , 46 , 99 , 111 , 109 , 225 , 54 , 136 , 221 , 188 , 252 , 142 , 137];
 
       vid.textTracks.addEventListener("addtrack", function(event) {
-        if (event.track.id == eissPid) {
-          eissTrack = event.track;
-        } else if (event.track.id == ebifPid) {
-          ebifTrack = event.track;
+        var track = event.track;
+        var type = null;
+        if (track.id == eissPid) {
+          eissTrack = track;
+          type = "EISS";
+        } else if (track.id == ebifPid) {
+          ebifTrack = track;
+          type = "EBIF";
+        } else {
+          return;
         }
-        event.track.mode = "hidden";
+        track.mode = "hidden";
+        var i = 0;
+        track.addEventListener("cuechange", function() {
+          test.step(function() {
+            var cue = track.cues[0];
+
+            assert_equals(cue.id, "", "DataCue.id");
+            assert_approx_equals(cue.startTime, 0, 0.1, "DataCue.startTime");
+
+            assert_greater_than_equal(cue.endTime + 0.01, cue.startTime, "DataCue.endTime");
+            assert_true(cue.data instanceof ArrayBuffer, "DataCue.data is ArrayBuffer");
+
+            if (i === 0) {
+              var cueData = new Uint8Array(cue.data);
+              assert_array_equals(type == "EISS" ? dataEiss : dataEbif, cueData, type + " DataCue.data");
+            }
+
+            assert_equals(cue.pauseOnExit, false, "DataCue.pauseOnExit");
+          }, type + " DataCues attributes.");
+          done();
+        });
       });
 
-      vid.addEventListener("playing", function() {
-        setTimeout(function() {
-          vid.pause();
-
-          if (!eissTrack) {
-            test.step(function() {
-              assert_unreached("Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
-            }, "Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
-            test.done();
-          } else if (!ebifTrack) {
-            test.step(function() {
-              assert_unreached("Did not find EISS TextTrack.id (" + ebifPid + ") in DOM.");
-            }, "Did not find EISS TextTrack.id (" + ebifPid + ") in DOM.");
-            test.done();
-          } else {
-            test.step(function() {
-              // EISS
-              for (var i = 0; i < eissTrack.cues.length; i++) {
-                var cue = eissTrack.cues[i];
-                var startTime = cue.startTime;
-                var endTime = cue.endTime;
-
-                assert_equals(cue.id, "", "DataCue.id");
-
-                if (i <= 13) {
-                  assert_approx_equals(startTime, 0, 0.1, "DataCue.startTime");
-                } else if (i <= 14) {
-                  assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime");
-                } else if (i <= 15) {
-                  assert_approx_equals(startTime, 3.52, 0.1, "DataCue.startTime");
-                } else if (i <= 16) {
-                  assert_approx_equals(startTime, 4.79, 0.1, "DataCue.startTime");
-                } else if (i <= 17) {
-                  assert_approx_equals(startTime, 5.59, 0.1, "DataCue.startTime");
-                } else if (i <= 18) {
-                  assert_approx_equals(startTime, 8.09, 0.1, "DataCue.startTime");
-                } else if (i <= 19) {
-                  assert_approx_equals(startTime, 10.46, 0.1, "DataCue.startTime");
-                }
-
-                assert_greater_than_equal(endTime + 0.01, startTime, "DataCue.endTime");
-                assert_true(cue.data instanceof ArrayBuffer, "DataCue.data is ArrayBuffer");
-
-                if (i === 0) {
-                  var cueData = new Uint8Array(cue.data);
-                  assert_array_equals(dataEiss, cueData, "EISS DataCue.data");
-                }
-
-                assert_equals(cue.pauseOnExit, false, "DataCue.pauseOnExit");
-              }
-
-              // EBIF
-              for (var i = 0; i < ebifTrack.cues.length; i++) {
-                var cue = ebifTrack.cues[i];
-                var startTime = cue.startTime;
-                var endTime = cue.endTime;
-
-                assert_equals(cue.id, "", "DataCue.id");
-
-                if (i <= 14) {
-                  assert_equals(startTime, 0, "DataCue.startTime");
-                } else if (i <= 15) {
-                   assert_approx_equals(startTime, 1.65, 0.1, "DataCue.startTime");
-                } else if (i <= 16) {
-                   assert_approx_equals(startTime, 3.15, 0.1, "DataCue.startTime");
-                } else if (i <= 17) {
-                   assert_approx_equals(startTime, 4.62, 0.1, "DataCue.startTime");
-                } else if (i <= 18) {
-                   assert_approx_equals(startTime, 5.52, 0.1, "DataCue.startTime");
-                } else if (i <= 19) {
-                   assert_approx_equals(startTime, 8.03, 0.1, "DataCue.startTime");
-                } else if (i <= 20) {
-                   assert_approx_equals(startTime, 10.06, 0.1, "DataCue.startTime");
-                }
-
-                assert_greater_than_equal(endTime + 0.01, startTime, "DataCue.endTime");
-                assert_true(cue.data instanceof ArrayBuffer,
-                            "DataCue.data is ArrayBuffer");
-
-                if (i === 0) {
-                  var cueData = new Uint8Array(cue.data);
-                  assert_array_equals(dataEbif, cueData, "EBIF DataCue.data");
-                }
-
-                assert_equals(cue.pauseOnExit, false, "DataCue.pauseOnExit");
-              }
-            }, "EBIF/EISS DataCues attributes.");
-            test.done();
-          }
-        }, 12000);
+      vid.addEventListener("canplaythrough", function() {
+        if (!vid.textTracks.getTrackById(eissPid)) {
+          test.step(function() {
+            assert_unreached("Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
+          }, "Did not find EBIF TextTrack.id (" + eissPid + ") in DOM.");
+          test.done();
+        } else if (!vid.textTracks.getTrackById(ebifPid)) {
+          test.step(function() {
+            assert_unreached("Did not find EISS TextTrack.id (" + ebifPid + ") in DOM.");
+          }, "Did not find EISS TextTrack.id (" + ebifPid + ") in DOM.");
+          test.done();
+        }
       }, false);
     </script>
   </body>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-2.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-2.html
@@ -10,30 +10,24 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. -->
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing two EISS streams and one program insertion cue stream.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing two EISS streams and one program insertion cue stream.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
       Reference [INBANDTRACKS]</a>
     </p>
-
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
-
-
     <script>
       var test = async_test("EISS TextTrack attributes.");
       var vid = document.getElementById("v");
@@ -46,7 +40,6 @@
       var kind = 'metadata';
       var language = '';
       var mode = 'disabled';
-
 
       vid.addEventListener("playing", function() {
         setTimeout(function() {
@@ -93,7 +86,6 @@
           }
         }, 12000);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-2.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-2.html
@@ -29,63 +29,57 @@
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
     <script>
-      var test = async_test("EISS TextTrack attributes.");
+      var test = async_test("EISS/EBIF TextTrack attributes.");
       var vid = document.getElementById("v");
       vid.src = mediaServerURL() + "UserPrivateStreams.ts";
 
-      var indexEiss = -1;
-      var indexEbif = -1;
-      var eissPid = '1768';  // EISS1 PID
-      var ebifPid = '1770';  // EISS2 PID
+      var eissPid = '1768';
+      var ebifPid = '1770';
       var kind = 'metadata';
       var language = '';
       var mode = 'disabled';
 
-      vid.addEventListener("playing", function() {
-        setTimeout(function() {
+      var sawTracks = 0;
+      vid.textTracks.addEventListener("addtrack", function(event) {
+        var track = event.track;
 
+        if (track.id === eissPid) {
+          test.step(function() {
+            assert_equals(track.id, eissPid, "TextTrackList1.id EISS1");
+            assert_equals(track.kind, kind, "TextTrack1.kind");
+            assert_equals(track.language, language, "TextTrack1.language");
+            assert_equals(track.mode, mode, "TextTrack1.mode");
+          }, "EISS TextTrack attributes");
+        } else if (track.id === ebifPid) {
+          test.step(function() {
+            assert_equals(track.id, ebifPid, "TextTrackList2.id EISS2");
+            assert_equals(track.kind, kind, "TextTrack2.kind");
+            assert_equals(track.language, language, "TextTrack2.language");
+            assert_equals(track.mode, mode, "TextTrack2.mode");
+          }, "EBIF TextTrack attributes");
+        } else {
+          return;
+        }
+        ++sawTracks;
+        if (sawTracks >= 2) {
+          test.done();
           vid.pause();
+        }
+      });
 
-          for (i=0; i< vid.textTracks.length; i++) {
-            if (vid.textTracks[i].id == eissPid) {
-              indexEiss = i;
-            }
-            if (vid.textTracks[i].id == ebifPid) {
-              indexEbif = i;
-            }
-          }
-
-          if (eissPid == -1) {
-            test.step(function() {
-              assert_unreached("Did not find first EISS TextTrack.id (PID) " + eissPid + " in DOM.");
-            }, "Did not find first EISS TextTrack.id (PID) " + eissPid + " in DOM.");
-            test.done();
-          }
-          else if (ebifPid == -1) {
-            test.step(function() {
-              assert_unreached("Did not find second EISS TextTrack.id (PID) " + ebifPid + " in DOM.");
-            }, "Did not find second EISS TextTrack.id (PID) " + ebifPid + " in DOM.");
-            test.done();
-
-          } else {
-            test.step(function() {
-              // EISS
-              assert_equals(vid.textTracks[indexEiss].id, eissPid, "TextTrackList1.id EISS1");
-              assert_equals(vid.textTracks[indexEiss].kind, kind, "TextTrack1.kind");
-              assert_equals(vid.textTracks[indexEiss].language, language, "TextTrack1.language");
-              assert_equals(vid.textTracks[indexEiss].mode, mode, "TextTrack1.mode");
-
-              // EBIF
-              assert_equals(vid.textTracks[indexEbif].id, ebifPid, "TextTrackList2.id EISS2");
-              assert_equals(vid.textTracks[indexEbif].kind, kind, "TextTrack2.kind");
-              assert_equals(vid.textTracks[indexEbif].language, language, "TextTrack2.language");
-              assert_equals(vid.textTracks[indexEbif].mode, mode, "TextTrack2.mode");
-            });
-
-            test.done();
-          }
-        }, 12000);
-      }, false);
+      vid.addEventListener("canplaythrough", function() {
+        if (!vid.textTracks.getTrackById(eissPid)) {
+          test.step(function() {
+            assert_unreached("Did not find first EISS TextTrack.id (PID) " + eissPid + " in DOM.");
+          }, "Did not find first EISS TextTrack.id (PID) " + eissPid + " in DOM.");
+          test.done();
+        } else if (!vid.textTracks.getTrackById(ebifPid)) {
+          test.step(function() {
+            assert_unreached("Did not find second EISS TextTrack.id (PID) " + ebifPid + " in DOM.");
+          }, "Did not find second EISS TextTrack.id (PID) " + ebifPid + " in DOM.");
+          test.done();
+        }
+      });
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-3.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-3.html
@@ -33,40 +33,29 @@
       var vid = document.getElementById("v");
       vid.src = mediaServerURL() + "UserPrivateStreams.ts"; 
 
-      var index = -1;
-      var pid = '45';  // Program Insertion Cue Message PID
-      var kind = 'metadata';
-      var language = '';
-      var mode = 'disabled';
+      var pid = '45'; // Program Insertion Cue Message PID
+
+      vid.textTracks.addEventListener("addtrack", function(event) {
+        var track = event.track;
+        if (track.id === pid) {
+          test.step(function() {
+            assert_equals(track.kind, "metadata", "TextTrack.kind");
+            assert_equals(track.language, "", "TextTrack.language");
+            assert_equals(track.mode, "disabled", "TextTrack.mode");
+          });
+          test.done();
+        }
+      });
 
       vid.addEventListener("playing", function() {
-
         vid.pause();
-
-        setTimeout(function() {
-          for (i=0; i< vid.textTracks.length; i++) {
-            if (vid.textTracks[i].id == pid) {
-              index++;
-              break;
-            }
-          }
-
-          if (index == -1) {
-            test.step(function() {
-              assert_unreached("Did not find  Program Insertion Cue TextTrack.id (PID) " + pid + " in DOM.");
-            }, "Did not find Program Insertion Cue TextTrack.id (PID) " + pid + " in DOM.");
-            test.done();
-
-          } else {
-            test.step(function() {
-              assert_equals(vid.textTracks[index].kind,     kind,     "TextTrack.kind");
-              assert_equals(vid.textTracks[index].language, language, "TextTrack.language");
-              assert_equals(vid.textTracks[index].mode,     mode,     "TextTrack.mode");
-            });
-            test.done();
-          }
-        }, 12000);
-      }, false);
+        if (!vid.textTracks.getTrackById(pid)) {
+          test.step(function() {
+            assert_unreached("Did not find  Program Insertion Cue TextTrack.id (PID) " + pid + " in DOM.");
+          }, "Did not find Program Insertion Cue TextTrack.id (PID) " + pid + " in DOM.");
+          test.done();
+        }
+      });
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-3.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-3.html
@@ -10,30 +10,24 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing two EISS streams, one program insertion cue stream.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing two EISS streams, one program insertion cue stream.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
       Reference [INBANDTRACKS]</a>
     </p>
-
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
-
-
     <script>
       var test = async_test("Program Insertion Cue TextTrack attributes.");
       var vid = document.getElementById("v");
@@ -44,7 +38,6 @@
       var kind = 'metadata';
       var language = '';
       var mode = 'disabled';
-
 
       vid.addEventListener("playing", function() {
 
@@ -74,7 +67,6 @@
           }
         }, 12000);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-4.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-4.html
@@ -10,20 +10,17 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing both 608 and 708 Closed Caption.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing both 608 and 708 Closed Caption.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
@@ -32,7 +29,6 @@
 
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
-
 
     <script>
       var test = async_test("Closed Caption TextTrack attributes.");
@@ -47,21 +43,17 @@
       var kind = 'captions';
       var language = 'en';
 
-
       vid.addEventListener("playing", function() {
         setTimeout(function() {
-
-          for (i=0; i< vid.textTracks.length; i++) {
-	    vid.textTracks[i].mode = 'hidden';
+          for (var i = 0; i < vid.textTracks.length; i++) {
+            vid.textTracks[i].mode = 'hidden';
           }
-
         }, 100);
 
-    setTimeout(function() {
-
+        setTimeout(function() {
           vid.pause();
 
-          for (i=0; i< vid.textTracks.length; i++) {
+          for (var i = 0; i< vid.textTracks.length; i++) {
             if (vid.textTracks[i].kind == kind) {
               vid.textTracks[i].mode = 'hidden';
               index = i;
@@ -71,26 +63,24 @@
 
           if (index == -1) {
             test.step(function() {
-              assert_unreached("Did not find Closed Caption Track (kind) "
-                               + kind + " in DOM.");
-            }, "Did not find Closed Caption Track (kind) "
-		      + kind + " in DOM.");
+              assert_unreached("Did not find Closed Caption Track (kind) " +
+                               kind + " in DOM.");
+            }, "Did not find Closed Caption Track (kind) " + kind + " in DOM.");
           }
 
           test.step(function() {
             assert_equals(vid.textTracks[index].id, captionServiceNumber, "TextTrack.id");
             assert_equals(vid.textTracks[index].kind, kind, "TextTrack.kind");
             assert_equals(vid.textTracks[index].language, language, "TextTrack.language");
-	    for (i=0; i < vid.textTracks[index].cues.length; i++) {
-	      assert_equals(vid.textTracks[index].cues[i].id, serviceNumber, "Cue.id");
-	    }
+            for (var i = 0; i < vid.textTracks[index].cues.length; i++) {
+              assert_equals(vid.textTracks[index].cues[i].id, serviceNumber, "Cue.id");
+            }
           });
 
           test.done();
 
         }, 24000);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.3-4.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.3-4.html
@@ -36,51 +36,33 @@
       vid.src = mediaServerURL() + "ClosedCaption.ts";
 
       var serviceNumber = '1';  // service number in service block
-      var captionServiceNumber = '1';  // caption service number in Caption Service Descriptor
-      var index = -1;
+      var id = '1';  // caption service number in Caption Service Descriptor
       // Currently, the specification under test indicates 'kind' == 'caption.' 
       // By W3C specification, 'kind' should be plural, 'captions.'
       var kind = 'captions';
       var language = 'en';
 
-      vid.addEventListener("playing", function() {
-        setTimeout(function() {
-          for (var i = 0; i < vid.textTracks.length; i++) {
-            vid.textTracks[i].mode = 'hidden';
-          }
-        }, 100);
-
-        setTimeout(function() {
-          vid.pause();
-
-          for (var i = 0; i< vid.textTracks.length; i++) {
-            if (vid.textTracks[i].kind == kind) {
-              vid.textTracks[i].mode = 'hidden';
-              index = i;
-              break;
-            }
-          }
-
-          if (index == -1) {
-            test.step(function() {
-              assert_unreached("Did not find Closed Caption Track (kind) " +
-                               kind + " in DOM.");
-            }, "Did not find Closed Caption Track (kind) " + kind + " in DOM.");
-          }
-
+      vid.textTracks.addEventListener("addtrack", function(event) {
+        var track = event.track;
+        track.mode = "hidden";
+        if (track.id === id) {
           test.step(function() {
-            assert_equals(vid.textTracks[index].id, captionServiceNumber, "TextTrack.id");
-            assert_equals(vid.textTracks[index].kind, kind, "TextTrack.kind");
-            assert_equals(vid.textTracks[index].language, language, "TextTrack.language");
-            for (var i = 0; i < vid.textTracks[index].cues.length; i++) {
-              assert_equals(vid.textTracks[index].cues[i].id, serviceNumber, "Cue.id");
-            }
+            assert_equals(track.kind, kind, "TextTrack.kind");
+            assert_equals(track.language, language, "TextTrack.language");
           });
-
           test.done();
-
-        }, 24000);
-      }, false);
+        }
+      });
+      vid.addEventListener("playing", function() {
+        vid.pause();
+        if (!vid.textTracks.getTrackById(id)) {
+          test.step(function() {
+            assert_unreached("Did not find Closed Caption Track with id " +
+                             id + " in DOM.");
+          });
+          test.done();
+        }
+      });
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.4-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.4-1.html
@@ -10,30 +10,24 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing one video elementary stream, ES PID 33.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing one video elementary stream, ES PID 33.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
       Reference [INBANDTRACKS]</a>
     </p>
-
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
-
-
     <script>
       var test = async_test("VideoTrack attributes.");
       var vid = document.getElementById("v");
@@ -43,9 +37,7 @@
       var pid = '33'; // video ES PID
       var kind = 'main';
 
-
       vid.addEventListener("playing", function() {
-
         vid.pause();
 
         setTimeout(function() {
@@ -71,7 +63,6 @@
           }
         }, 12000);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.4-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.4-1.html
@@ -33,36 +33,28 @@
       var vid = document.getElementById("v");
       vid.src = mediaServerURL() + "UserPrivateStreams.ts";
 
-      var index = -1;
-      var pid = '33'; // video ES PID
-      var kind = 'main';
+      var pid = "33"; // video ES PID
+      var kind = "main";
+
+      vid.videoTracks.addEventListener("addtrack", function(event) {
+        var track = event.track;
+        test.step(function() {
+          assert_equals(vid.videoTracks.length, 1, "VideoTracks.length");
+          assert_equals(track.id, pid, "VideoTrack.id");
+          assert_equals(track.kind, kind, "VideoTrack.kind");
+        });
+        test.done();
+      });
 
       vid.addEventListener("playing", function() {
         vid.pause();
-
-        setTimeout(function() {
-          for (i=0; i< vid.videoTracks.length; i++) {
-            if (vid.videoTracks[i].id == pid) {
-              index = i;
-              break;
-            }
-          }
-          if (index == -1) {
-            test.step(function() {
-              assert_unreached("Did not find VideoTrack PID " + pid + " in DOM");
-            }, "Did not find VideoTrack " + pid + " in DOM");
-            test.done();
-
-          } else {
-            test.step(function() {
-              assert_equals(vid.videoTracks.length, 1, "VideoTracks.length");
-              assert_equals(vid.videoTracks[index].id, pid, "VideoTrack.id");
-              assert_equals(vid.videoTracks[index].kind, kind, "VideoTrack.kind");
-            });
-            test.done();
-          }
-        }, 12000);
-      }, false);
+        if (!vid.videoTracks.getTrackById(pid)) {
+          test.step(function() {
+            assert_unreached("Did not find VideoTrack PID " + pid + " in DOM");
+          }, "Did not find VideoTrack " + pid + " in DOM");
+          test.done();
+        }
+      });
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.4-2.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.4-2.html
@@ -10,20 +10,17 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing two audio elementary streams, ES PIDs 36, 41.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing two audio elementary streams, ES PIDs 36, 41.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
@@ -32,7 +29,6 @@
 
     <audio id="a" width="400" height="300" autoplay controls></audio>
     <div id="log"></div>
-
 
     <script>
       var test = async_test("AudioTracks attributes.");
@@ -46,10 +42,8 @@
       var kind1 = 'main';
       var kind2 = '';
 
-
       aud.addEventListener("playing", function() {
         setTimeout(function() {
-
           aud.pause();
 
           for (i=0; i< aud.audioTracks.length; i++) {
@@ -85,7 +79,6 @@
           }
         }, 12000);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.4-2.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.4-2.html
@@ -35,49 +35,30 @@
       var aud = document.getElementById("a");
       aud.src = mediaServerURL() + "ClosedCaption.ts"; 
 
-      var index1 = -1;
-      var index2 = -1;
-      var pid1 = '36'; // audio1 ES PID
-      var pid2 = '41'; // audio2 ES PID
-      var kind1 = 'main';
-      var kind2 = '';
+      var expectedTracks = [
+        {
+          id: "36",
+          kind: "main"
+        }, {
+          id: "41",
+          kind: ""
+        }
+      ];
 
       aud.addEventListener("playing", function() {
-        setTimeout(function() {
-          aud.pause();
+        aud.pause();
 
-          for (i=0; i< aud.audioTracks.length; i++) {
-            if (aud.audioTracks[i].id == pid1) {
-              index1 = i;
-            }
-            if (aud.audioTracks[i].id == pid2) {
-              index2 = i;
-            }
+        test.step(function() {
+          assert_equals(aud.audioTracks.length, expectedTracks.length, "AudioTrackList.length");
+          for (var i = 0; i < expectedTracks.length; ++i) {
+            var expected = expectedTracks[i];
+            // These should be in PMT order
+            var actual = aud.audioTracks[i];
+            assert_equals(actual.id, expected.id, "AudioTrackList[" + i + "].id");
+            assert_equals(actual.kind, expected.kind, "AudioTrack[" + i + "].kind");
           }
-
-          if (index1 == -1) {
-            test.step(function() {
-              assert_unreached("Did not find first AudioTrack PID " + pid1 + " in DOM");
-            }, "Did not find first AudioTrack PID " + pid1 + " in DOM");
-            test.done();
-
-          } else if (index2 == -1) {
-            test.step(function() {
-              assert_unreached("Did not find second AudioTrack PID " + pid2 + " in DOM");
-            }, "Did not find second AudioTrack PID " + pid2 + " in DOM");
-            test.done();
-
-          } else {
-            test.step(function() {
-              assert_equals(aud.audioTracks.length,       2,     "AudioTracks.length");
-              assert_equals(aud.audioTracks[index1].id,   pid1,  "AudioTrack1.id");
-              assert_equals(aud.audioTracks[index1].kind, kind1, "AudioTrack1.kind");
-              assert_equals(aud.audioTracks[index2].id,   pid2,  "AudioTrack2.id");
-              assert_equals(aud.audioTracks[index2].kind, kind2, "AudioTrack2.kind");
-            });
-            test.done();
-          }
-        }, 12000);
+        });
+        test.done();
       }, false);
     </script>
   </body>

--- a/mpegmap/HTMLSourcingInbandTracks-3.5.b-1-manual.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.5.b-1-manual.html
@@ -10,20 +10,17 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing both 608 and 708 Closed Caption.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing both 608 and 708 Closed Caption.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
@@ -32,10 +29,8 @@
 
     <video id="v" width="400" height="300" autoplay controls></video>
     <div>The subtitles must display and contain the characters specified
-    by on the video.</div>
+      by on the video.</div>
     <div id="log"></div>
-
-
     <script>
       var test = async_test("Closed Caption TextTrack attributes.");
       var vid = document.getElementById("v");
@@ -43,14 +38,11 @@
 
       vid.addEventListener("playing", function() {
         setTimeout(function() {
-
-          for (i=0; i< vid.textTracks.length; i++) {
-	    vid.textTracks[i].mode = 'showing';
+          for (var i = 0; i < vid.textTracks.length; i++) {
+            vid.textTracks[i].mode = 'showing';
           }
-
         }, 100);
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.5.b-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.5.b-1.html
@@ -34,67 +34,45 @@
       var vid = document.getElementById("v");
       vid.src = mediaServerURL() + "ClosedCaption.ts"; 
 
-      var index = -1;
       var pid = "33"; // video stream (Closed Caption) PID
-      var hasNotPlayed = true;
-      var hasNotPaused = true;
-      var failed = false;
       var firstPassCues = null;
       var secondPassCues = null;
       var kind = "captions";
+      var track = null;
 
-      vid.addEventListener("playing", function() {
-        if (hasNotPlayed) {
-          hasNotPlayed = false;
-
-          setTimeout(function() {
-            for (var i = 0; i < vid.textTracks.length; i++) {
-              if (vid.textTracks[i].kind == kind) {
-                vid.textTracks[i].mode = 'hidden';
-                index = i;
-                break;
-              }
-            }
-
-            if (index === -1) {
-              hasNotPaused = false;
-              vid.pause();
-
-              test.step(function() {
-                assert_unreached("Did not find Closed Caption Track (kind) " +
-                                 kind + " in DOM.");
-              }, "Did not find Closed Caption Track (kind) " + kind + " in DOM.");
-              failed = true;
-              test.done();
-            }
-          }, 15000);
-
-          setTimeout(function() {
-            if (!failed) {
-              vid.textTracks[index].mode = 'hidden';
+      vid.textTracks.addEventListener("addtrack", function(event) {
+        if (event.track.kind === kind) {
+          track = event.track;
+          track.mode = "hidden";
+          track.addEventListener("cuechange", function() {
+            if (!firstPassCues) {
               firstPassCues = [];
-              for (var i = 0; i < vid.textTracks[index].cues.length; i++) {
-                firstPassCues[i] = vid.textTracks[index].cues[i];
+              for (var i = 0; i < track.cues.length; i++) {
+                firstPassCues[i] = track.cues[i];
               }
-              vid.pause();
               vid.currentTime = 0;
             }
-          }, 18000);
+          });
         }
-      }, false);
+      });
 
-      vid.addEventListener("pause", function() {
-        if (hasNotPaused) {
-          hasNotPaused = false;
+      setTimeout(function() {
+        if (!track) {
+          vid.pause();
+          test.step(function() {
+            assert_unreached("Did not find Closed Caption Track (kind) " +
+                             kind + " in DOM.");
+          }, "Did not find Closed Caption Track (kind) " + kind + " in DOM.");
+          test.done();
+        }
+      }, 2000);
 
-          setTimeout(function() {
-            vid.play();
-          }, 3000);
-
-          setTimeout(function() {
+      vid.addEventListener("seeked", function() {
+        track.addEventListener("cuechange", function() {
+          if (!secondPassCues) {
             secondPassCues = [];
-            for (var i = 0; i < vid.textTracks[index].cues.length; i++) {
-              secondPassCues[i] = vid.textTracks[index].cues[i];
+            for (var i = 0; i < track.cues.length; i++) {
+              secondPassCues[i] = track.cues[i];
             }
 
             test.step(function() {
@@ -102,24 +80,16 @@
                                 "First play, Closed Caption, TextTrackCues.length was 0.");
               assert_not_equals(secondPassCues.length, 0,
                                 "Second play, Closed Caption, TextTrackCues.length was 0.");
-            });
-
-            test.step(function() {
-              for (var i = 0; i < secondPassCues.length; i++) {
-                for (var j = i + 1; j < secondPassCues.length; j++) {
-                  assert_not_equals(secondPassCues[i].text, secondPassCues[j].text,
-                                    'Cue[' + i + ']' + ' was duplicated.');
-                }
+              for (var i = 0; i < firstPassCues.length && i < secondPassCues.length; i++) {
+                  assert_equals(secondPassCues[i].text, firstPassCues[i].text,
+                                    'Cue[' + i + ']' + ' was different the second time.');
               }
             });
-          }, 15000);
-
-          setTimeout(function() {
-            vid.pause();
             test.done();
-          }, 18000);
-        }
-      }, false);
+            vid.pause();
+          }
+        });
+      });
     </script>
   </body>
 </html>

--- a/mpegmap/HTMLSourcingInbandTracks-3.5.b-1.html
+++ b/mpegmap/HTMLSourcingInbandTracks-3.5.b-1.html
@@ -10,20 +10,17 @@
     <!-- Source HTTP server local copy of World Wide Web Consortium (W3C) Test Harness. --> 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-
     <!-- Script Version: BETA -->
-
     <!-- About the Media Resource
-           To verify DOM elements the details of the test media must be known prior to test execution.
-           This test script is bound to the test media file sourced in the script.
-           Sourcing a differnt test media file, or modifying that file, may invalidate the test.
 
-           The media is an MPEG-2, Single Program Transport Stream
-           containing both 608 and 708 Closed Caption.
+         To verify DOM elements the details of the test media must be known prior to test execution.
+         This test script is bound to the test media file sourced in the script.
+         Sourcing a differnt test media file, or modifying that file, may invalidate the test.
+
+         The media is an MPEG-2, Single Program Transport Stream
+         containing both 608 and 708 Closed Caption.
     -->
   </head>
-
-
   <body>
     <p>
       <a href="http://www.w3.org/TR/html5/references.html#refsINBANDTRACKS">Spec
@@ -32,8 +29,6 @@
 
     <video id="v" width="400" height="300" autoplay controls></video>
     <div id="log"></div>
-
-
     <script>
       var test = async_test("Backward Seek Closed Caption Cues.");
       var vid = document.getElementById("v");
@@ -50,28 +45,25 @@
 
       vid.addEventListener("playing", function() {
         if (hasNotPlayed) {
-
           hasNotPlayed = false;
 
           setTimeout(function() {
-
-            for (i=0; i< vid.textTracks.length; i++) {
+            for (var i = 0; i < vid.textTracks.length; i++) {
               if (vid.textTracks[i].kind == kind) {
-		vid.textTracks[i].mode = 'hidden';
-		index = i;
-		break;
+                vid.textTracks[i].mode = 'hidden';
+                index = i;
+                break;
               }
             }
 
-            if (index == -1) {
+            if (index === -1) {
               hasNotPaused = false;
               vid.pause();
 
               test.step(function() {
-		assert_unreached("Did not find Closed Caption Track (kind) "
-				 + kind + " in DOM.");
-              }, "Did not find Closed Caption Track (kind) "
-			+ kind + " in DOM.");
+                assert_unreached("Did not find Closed Caption Track (kind) " +
+                                 kind + " in DOM.");
+              }, "Did not find Closed Caption Track (kind) " + kind + " in DOM.");
               failed = true;
               test.done();
             }
@@ -80,8 +72,8 @@
           setTimeout(function() {
             if (!failed) {
               vid.textTracks[index].mode = 'hidden';
-              firstPassCues = new Array();
-              for (i=0; i < vid.textTracks[index].cues.length; i++) {
+              firstPassCues = [];
+              for (var i = 0; i < vid.textTracks[index].cues.length; i++) {
                 firstPassCues[i] = vid.textTracks[index].cues[i];
               }
               vid.pause();
@@ -91,20 +83,17 @@
         }
       }, false);
 
-
       vid.addEventListener("pause", function() {
         if (hasNotPaused) {
-
           hasNotPaused = false;
 
           setTimeout(function() {
             vid.play();
           }, 3000);
 
-
           setTimeout(function() {
-            secondPassCues = new Array();
-            for (i=0; i < vid.textTracks[index].cues.length; i++) {
+            secondPassCues = [];
+            for (var i = 0; i < vid.textTracks[index].cues.length; i++) {
               secondPassCues[i] = vid.textTracks[index].cues[i];
             }
 
@@ -116,12 +105,12 @@
             });
 
             test.step(function() {
-              for (i = 0; i < secondPassCues.length; i++) {
-                for (j = i+1; j < secondPassCues.length; j++) {
+              for (var i = 0; i < secondPassCues.length; i++) {
+                for (var j = i + 1; j < secondPassCues.length; j++) {
                   assert_not_equals(secondPassCues[i].text, secondPassCues[j].text,
-				    'Cue[' + i + ']' + ' was duplicated.');
+                                    'Cue[' + i + ']' + ' was duplicated.');
                 }
-	      }
+              }
             });
           }, 15000);
 
@@ -131,7 +120,6 @@
           }, 18000);
         }
       }, false);
-
     </script>
   </body>
 </html>

--- a/mpegmap/testmedia.js
+++ b/mpegmap/testmedia.js
@@ -18,5 +18,5 @@
  */
 function mediaServerURL()
 {
-  return "http://web-platform.test:80/media/";
+  return "/media/";
 }

--- a/mpegmap/testmedia.js
+++ b/mpegmap/testmedia.js
@@ -10,16 +10,13 @@
  * URI to source the test media file for that test.
  * Edit the return value of mediaServerURL() to return the URL of your media test server.
  *
- *    e.g.  video.src = mediaServerURL() + "UserPrivateStreams.ts";
- *
+ * e.g. video.src = mediaServerURL() + "UserPrivateStreams.ts";
  */
-
 
 /*
- * Return URL of media server. 
+ * Return URL of media server.
  */
-  function mediaServerURL()
-  {
-    //return "http://localhost:80/media/";
-    return "http://web-platform.test:80/media/";
-  }
+function mediaServerURL()
+{
+  return "http://web-platform.test:80/media/";
+}


### PR DESCRIPTION
I went through these tests to use events instead of timeouts where possible, so the tests now run much faster. Some of them pass on our WebKitGTK+ branch, but for some reason the AudioTrack and VideoTrack id's are wrong. I think the tests are working correctly though.